### PR TITLE
fix typo on Realtime data as Stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ main() {
 
 ### Realtime data as `Stream`
 
-To receive relatime updates, you have to first enable Realtime on from your Supabase console. You can read more [here](https://supabase.io/docs/guides/api#managing-realtime) on how to enable it.
+To receive realtime updates, you have to first enable Realtime on from your Supabase console. You can read more [here](https://supabase.io/docs/guides/api#managing-realtime) on how to enable it.
 
 ```dart
 import 'package:supabase/supabase.dart';


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update a typo on Readme.md file for the section Realtime data as a Stream.

## What is the current behavior?

To receive **relatime** updates, you have to first enable Realtime on from your Supabase console. You can read more here on how to enable it.

## What is the new behavior?

To receive **realtime** updates, you have to first enable Realtime on from your Supabase console. You can read more here on how to enable it.

## Additional context

Just update a typo on the Readme.md file.