### PR TITLE
docs: correct stream method documentation

### DIFF
--- a/lib/src/supabase.dart
+++ b/lib/src/supabase.dart
@@ -5,9 +5,8 @@ import 'package:postgrest/postgrest.dart';
 import 'package:realtime_client/realtime_client.dart';
 import 'package:storage_client/storage_client.dart';
 import 'package:supabase/src/constants.dart';
+import 'package:supabase/src/supabase_query_builder.dart';
 import 'package:supabase/src/supabase_stream_builder.dart';
-
-import 'supabase_query_builder.dart';
 
 class SupabaseClient {
   final String supabaseUrl;

--- a/lib/src/supabase_query_builder.dart
+++ b/lib/src/supabase_query_builder.dart
@@ -1,10 +1,9 @@
 import 'package:postgrest/postgrest.dart';
 import 'package:realtime_client/realtime_client.dart';
+import 'package:supabase/src/supabase_event_types.dart';
+import 'package:supabase/src/supabase_realtime_client.dart';
 import 'package:supabase/src/supabase_realtime_payload.dart';
 import 'package:supabase/src/supabase_stream_builder.dart';
-
-import 'supabase_event_types.dart';
-import 'supabase_realtime_client.dart';
 
 class SupabaseQueryBuilder extends PostgrestQueryBuilder {
   late final SupabaseRealtimeClient _subscription;

--- a/lib/src/supabase_query_builder.dart
+++ b/lib/src/supabase_query_builder.dart
@@ -46,10 +46,10 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder {
   /// supabase.from('chats').stream().execute().listen(_onChatsReceived);
   /// ```
   ///
-  /// `eq`, `orderBy`, `limit` filter are available to limit the data being queried.
+  /// `eq`, `order`, `limit` filter are available to limit the data being queried.
   ///
   /// ```dart
-  /// supabase.from('chats:room_id=eq.123').orderBy('created_at').limit(20).stream().listen(_onChatsReceived);
+  /// supabase.from('chats:room_id=eq.123').stream().order('created_at').limit(20).execute().listen(_onChatsReceived);
   /// ```
   ///
   SupabaseStreamBuilder stream() {

--- a/lib/src/supabase_realtime_client.dart
+++ b/lib/src/supabase_realtime_client.dart
@@ -1,7 +1,6 @@
 import 'package:realtime_client/realtime_client.dart';
-
-import 'supabase_event_types.dart';
-import 'supabase_realtime_payload.dart';
+import 'package:supabase/src/supabase_event_types.dart';
+import 'package:supabase/src/supabase_realtime_payload.dart';
 
 typedef SubscribeCallback = void Function(String event, {String? errorMsg});
 

--- a/lib/src/supabase_realtime_payload.dart
+++ b/lib/src/supabase_realtime_payload.dart
@@ -33,8 +33,13 @@ class SupabaseRealtimePayload {
     final commitTimestamp = json['commit_timestamp'] as String;
     final eventType = json['type'] as String;
     final primaryKeys = (json['columns'] as List)
-        .where((e) => (e['flags'] as List?)?.contains('key') == true)
-        .map((e) => e['name'] as String)
+        .where(
+          (e) =>
+              ((e as Map<String, dynamic>)['flags'] as List?)
+                  ?.contains('key') ==
+              true,
+        )
+        .map((e) => (e as Map<String, dynamic>)['name'] as String)
         .toList();
     Map<String, dynamic>? newRecord;
     if (json['type'] == 'INSERT' || json['type'] == 'UPDATE') {

--- a/lib/src/supabase_stream_builder.dart
+++ b/lib/src/supabase_stream_builder.dart
@@ -1,8 +1,7 @@
 import 'dart:async';
 
 import 'package:supabase/src/supabase_realtime_payload.dart';
-
-import '../supabase.dart';
+import 'package:supabase/supabase.dart';
 
 class StreamPostgrestFilter {
   StreamPostgrestFilter({

--- a/test/mock_test.dart
+++ b/test/mock_test.dart
@@ -71,7 +71,7 @@ void main() {
           hasListener = true;
           webSocket!.listen((request) async {
             if (!hasSentData) {
-              final topic = jsonDecode(request as String)['topic'];
+              final topic = (jsonDecode(request as String) as Map)['topic'];
               final jsonString = jsonEncode({
                 'topic': topic,
                 'event': 'INSERT',
@@ -135,7 +135,7 @@ void main() {
 
   test('test mock server', () async {
     final res = await client.from('todos').select('task, status').execute();
-    expect(res.data.length, 2);
+    expect((res.data as List).length, 2);
   });
 
   test('stream() emits data', () {


### PR DESCRIPTION
The documentation of the `stream` method had several issues. `orderBy` came before `stream` and `orderBy` is in reality `order` and one `execute` was missing.