### PR TITLE
fix!: stream replaces the correct row

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -64,7 +64,7 @@ Future<void> main() async {
   // stream
   final streamSubscription = client
       .from('countries')
-      .stream()
+      .stream('id')
       .order('name')
       .limit(10)
       .execute()

--- a/lib/src/supabase_query_builder.dart
+++ b/lib/src/supabase_query_builder.dart
@@ -43,16 +43,19 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder {
   /// Notifies of data at the queried table
   ///
   /// ```dart
-  /// supabase.from('chats').stream().execute().listen(_onChatsReceived);
+  /// supabase.from('chats').stream('my_primary_key').execute().listen(_onChatsReceived);
   /// ```
   ///
   /// `eq`, `orderBy`, `limit` filter are available to limit the data being queried.
   ///
   /// ```dart
-  /// supabase.from('chats:room_id=eq.123').orderBy('created_at').limit(20).stream().listen(_onChatsReceived);
+  /// supabase.from('chats:room_id=eq.123').stream('my_primary_key').order('created_at').limit(20).execute().listen(_onChatsReceived);
   /// ```
-  ///
-  SupabaseStreamBuilder stream() {
-    return SupabaseStreamBuilder(this, streamFilter: _streamFilter);
+  SupabaseStreamBuilder stream(String primaryKey) {
+    return SupabaseStreamBuilder(
+      this,
+      streamFilter: _streamFilter,
+      primaryKey: primaryKey,
+    );
   }
 }

--- a/lib/src/supabase_realtime_payload.dart
+++ b/lib/src/supabase_realtime_payload.dart
@@ -15,6 +15,9 @@ class SupabaseRealtimePayload {
   final Map<String, dynamic>? oldRecord;
 
   /// List of columns that are set as primary key
+  @Deprecated(
+    "The new RLS real-time server no longer sends the required data",
+  )
   final List<String> primaryKeys;
 
   SupabaseRealtimePayload({
@@ -24,7 +27,10 @@ class SupabaseRealtimePayload {
     required this.table,
     required this.newRecord,
     required this.oldRecord,
-    required this.primaryKeys,
+    @Deprecated(
+      "The new RLS real-time server no longer sends the required data",
+    )
+        required this.primaryKeys,
   });
 
   factory SupabaseRealtimePayload.fromJson(Map<String, dynamic> json) {
@@ -55,6 +61,7 @@ class SupabaseRealtimePayload {
       eventType: eventType,
       newRecord: newRecord,
       oldRecord: oldRecord,
+      // ignore: deprecated_member_use_from_same_package
       primaryKeys: primaryKeys,
     );
   }

--- a/lib/src/supabase_stream_builder.dart
+++ b/lib/src/supabase_stream_builder.dart
@@ -41,11 +41,16 @@ class SupabaseStreamBuilder {
   /// `eq` filter used for both postgrest and realtime
   late final StreamPostgrestFilter? _streamFilter;
 
+  /// Used to identify which row has changed
+  final String _primaryKey;
+
   SupabaseStreamBuilder(
     SupabaseQueryBuilder queryBuilder, {
     required StreamPostgrestFilter? streamFilter,
+    required String primaryKey,
   })  : _queryBuilder = queryBuilder,
-        _streamFilter = streamFilter;
+        _streamFilter = streamFilter,
+        _primaryKey = primaryKey;
 
   /// Which column to order by and whether it's ascending
   _Order? _orderBy;
@@ -58,7 +63,7 @@ class SupabaseStreamBuilder {
   /// When `ascending` value is true, the result will be in ascending order.
   ///
   /// ```dart
-  /// supabase.from('users').stream().order('username', ascending: false);
+  /// supabase.from('users').stream('id).order('username', ascending: false);
   /// ```
   SupabaseStreamBuilder order(String column, {bool ascending = false}) {
     _orderBy = _Order(column: column, ascending: ascending);
@@ -68,7 +73,7 @@ class SupabaseStreamBuilder {
   /// Limits the result with the specified `count`.
   ///
   /// ```dart
-  /// supabase.from('users').stream().limit(10);
+  /// supabase.from('users').stream('id).limit(10);
   /// ```
   SupabaseStreamBuilder limit(int count) {
     _limit = count;
@@ -146,7 +151,7 @@ class SupabaseStreamBuilder {
     _addStream();
   }
 
-  static bool _isTargetRecord({
+  bool _isTargetRecord({
     required Map<String, dynamic> record,
     required SupabaseRealtimePayload payload,
   }) {
@@ -157,13 +162,7 @@ class SupabaseStreamBuilder {
       targetRecord = payload.oldRecord!;
     }
 
-    bool isTarget = true;
-    for (final primaryKey in payload.primaryKeys) {
-      if (record[primaryKey] != targetRecord[primaryKey]) {
-        isTarget = false;
-      }
-    }
-    return isTarget;
+    return record[_primaryKey] == targetRecord[_primaryKey];
   }
 
   void _sortData() {

--- a/test/mock_test.dart
+++ b/test/mock_test.dart
@@ -84,19 +84,16 @@ void main() {
                   'type': 'INSERT',
                   'columns': [
                     {
-                      'flags': ['key'],
                       'name': 'id',
                       'type': 'int4',
-                      'type_modifier': 4294967295
+                      'type_modifier': 4294967295,
                     },
                     {
-                      'flags': [],
                       'name': 'task',
                       'type': 'text',
                       'type_modifier': 4294967295
                     },
                     {
-                      'flags': [],
                       'name': 'status',
                       'type': 'bool',
                       'type_modifier': 4294967295
@@ -139,7 +136,7 @@ void main() {
   });
 
   test('stream() emits data', () {
-    final stream = client.from('todos').stream().execute();
+    final stream = client.from('todos').stream('id').execute();
     expect(
       stream,
       emitsInOrder([
@@ -157,7 +154,7 @@ void main() {
   });
 
   test('Can filter stream results with eq', () {
-    final stream = client.from('todos:status=eq.true').stream().execute();
+    final stream = client.from('todos:status=eq.true').stream('id').execute();
     expect(
       stream,
       emitsInOrder([
@@ -173,7 +170,7 @@ void main() {
   });
 
   test('stream() with order', () {
-    final stream = client.from('todos').stream().order('id').execute();
+    final stream = client.from('todos').stream('id').order('id').execute();
     expect(
       stream,
       emitsInOrder([
@@ -191,7 +188,8 @@ void main() {
   });
 
   test('stream() with limit', () {
-    final stream = client.from('todos').stream().order('id').limit(2).execute();
+    final stream =
+        client.from('todos').stream('id').order('id').limit(2).execute();
     expect(
       stream,
       emitsInOrder([


### PR DESCRIPTION
The `stream` method needs now the primary key as parameter to detect the updated row correctly.

I've marked the `primaryKeys` list from 'SupabaseRealtimePayload'  as deprecated, because it's on the new RLS Realtime server always empty. 

As far as I know, there aren't any Supabase instances running without RLS Realtime anymore, so I think it's okay to force that parameter and don't be backward compatible. We could remove `primaryKeys` instead of marking it deprecated, too.

close #74 #78 