### PR TITLE
Fixed changedAccessToken never initialized when changing account

### DIFF
--- a/lib/src/supabase.dart
+++ b/lib/src/supabase.dart
@@ -20,7 +20,7 @@ class SupabaseClient {
 
   late final GoTrueClient auth;
   late final RealtimeClient realtime;
-  late String? changedAccessToken;
+  String? changedAccessToken;
 
   SupabaseClient(
     this.supabaseUrl,


### PR DESCRIPTION
When logging out and back in with a different account, the changedAccessToken variable marked as late is not initialized.
Just changing it to a nullable variable fixes the issue.
