### PR TITLE
fix: add missing changedAccessToken initialization

### DIFF
--- a/lib/src/supabase.dart
+++ b/lib/src/supabase.dart
@@ -33,6 +33,7 @@ class SupabaseClient {
         authUrl = '$supabaseUrl/auth/v1',
         storageUrl = '$supabaseUrl/storage/v1',
         schema = schema ?? 'public',
+        changedAccessToken = null,
         _headers = headers {
     auth = _initSupabaseAuthClient(
       autoRefreshToken: autoRefreshToken,


### PR DESCRIPTION
Version 0.2.11 is missing an initialization for changedAccessToken in "supabase.dart".
What results in this error:
```sh
VERBOSE-2:ui_dart_state.cc(209)] Unhandled Exception: LateInitializationError: Field 'changedAccessToken' has not been initialized.
#0      SupabaseClient.changedAccessToken (package:supabase/src/supabase.dart)
package:supabase/src/supabase.dart:1
#1      SupabaseClient._handleTokenChanged
package:supabase/src/supabase.dart:171
#2      SupabaseClient._listenForAuthEvents.<anonymous closure>
package:supabase/src/supabase.dart:165
#3      GoTrueClient._notifyAllSubscribers.<anonymous closure>
package:gotrue/src/gotrue_client.dart:442
#4      _LinkedHashMapMixin.forEach (dart:collection-patch/compact_hash.dart:539:8)
#5      GoTrueClient._notifyAllSubscribers
package:gotrue/src/gotrue_client.dart:442
#6      GoTrueClient._handleEmailSignIn
package:gotrue/src/gotrue_client.dart:353
<asynchronous suspension>
```
when trying to sign in a user.