### PR TITLE
chore: publish version 0.2.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ build/
 # Directory created by dartdoc
 doc/api/
 
-# The .vscode folder contains launch configuration and tasks you configure in
-# VS Code which you may wish to be included in version control, so this line
-# is commented out by default.
+# General editor configs
 .vscode/
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.2.15]
+
+- chore: update gotrue_client to v0.1.6
+
 ## [0.2.14]
 
 - chore: update gotrue_client to v0.1.5

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '0.2.14';
+const version = '0.2.15';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,11 +8,11 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  gotrue: ^0.1.5
+  gotrue: ^0.1.6
   postgrest: ^0.1.9
   realtime_client: ^0.1.15
   storage_client: ^0.0.6+2
 
 dev_dependencies:
-  lint: ^1.5.2
-  test: ^1.16.5
+  lint: ^1.5.3
+  test: ^1.17.9


### PR DESCRIPTION
This updates gotrue_client to have the updated `signIn` with OpenID to help support native auth

Related:
https://github.com/supabase-community/gotrue-dart/pull/61
I then need to update https://github.com/supabase-community/supabase-flutter