### PR TITLE
fix: updated version in pubspec.yml to 0.2.15

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: supabase
 description: A dart client for Supabase. This client makes it simple for developers to build secure and scalable products.
-version: 0.2.14
-homepage: "https://supabase.io"
-repository: "https://github.com/supabase/supabase-dart"
+version: 0.2.15
+homepage: 'https://supabase.io'
+repository: 'https://github.com/supabase/supabase-dart'
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   gotrue: ^0.1.6


### PR DESCRIPTION
Updated the `version` within pubspec.yaml, which I totally missed in [this PR](https://github.com/supabase-community/supabase-dart/pull/98). 