### PR TITLE
fix: add changelog for v0.3.1+1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.3.1+1]
+
+- feat: exporting classes of functions_client
+
 ## [0.3.1]
 
 - feat: add functions support


### PR DESCRIPTION
I am so silly, but I forgot to add changelog for 0.3.1+1. This PR adds it. 