### PR TITLE
refac: :recycle: refactoring of Realtime subscription remove functions

### DIFF
--- a/lib/src/remove_subscription_result.dart
+++ b/lib/src/remove_subscription_result.dart
@@ -1,0 +1,11 @@
+import 'package:supabase/src/supabase_realtime_error.dart';
+
+class RemoveSubscriptionResult {
+  const RemoveSubscriptionResult({required this.openSubscriptions, this.error});
+  final int openSubscriptions;
+  final SupabaseRealtimeError? error;
+
+  @override
+  String toString() =>
+      'RemoveSubscriptionResult(openSubscriptions: $openSubscriptions, error: $error)';
+}

--- a/lib/src/supabase.dart
+++ b/lib/src/supabase.dart
@@ -96,7 +96,11 @@ class SupabaseClient {
     final allSubs = [...getSubscriptions()];
     final allSubsFutures = allSubs.map((sub) => removeSubscription(sub));
     final allRemovedSubs = await Future.wait(allSubsFutures);
-    return allRemovedSubs.map((e) => allSubs[e]).toList();
+    final removed = <RealtimeSubscription>[];
+    for (var i = 0; i < allRemovedSubs.length; i++) {
+      removed.add(allSubs[i]);
+    }
+    return removed;
   }
 
   /// Closes and removes a subscription and returns the number of open subscriptions.

--- a/lib/src/supabase.dart
+++ b/lib/src/supabase.dart
@@ -6,7 +6,9 @@ import 'package:postgrest/postgrest.dart';
 import 'package:realtime_client/realtime_client.dart';
 import 'package:storage_client/storage_client.dart';
 import 'package:supabase/src/constants.dart';
+import 'package:supabase/src/remove_subscription_result.dart';
 import 'package:supabase/src/supabase_query_builder.dart';
+import 'package:supabase/src/supabase_realtime_error.dart';
 import 'package:supabase/src/supabase_stream_builder.dart';
 
 class SupabaseClient {
@@ -105,19 +107,24 @@ class SupabaseClient {
 
   /// Closes and removes a subscription and returns the number of open subscriptions.
   /// [subscription]: subscription The subscription you want to close and remove.
-  Future<int> removeSubscription(RealtimeSubscription subscription) async {
+  Future<RemoveSubscriptionResult> removeSubscription(
+    RealtimeSubscription subscription,
+  ) async {
     final completer = Completer<int>();
 
-    await _closeSubscription(subscription);
+    final closeSubscriptionResult = await _closeSubscription(subscription);
     final allSubs = [...getSubscriptions()];
     final openSubsCount =
         allSubs.where((sub) => sub.isJoined()).toList().length;
     if (openSubsCount == 0) {
-      realtime.disconnect();
+      realtime.disconnect(reason: 'all subscriptions closed');
     }
     completer.complete(openSubsCount);
 
-    return completer.future;
+    return RemoveSubscriptionResult(
+      openSubscriptions: openSubsCount,
+      error: closeSubscriptionResult,
+    );
   }
 
   /// Returns an array of all your subscriptions.
@@ -158,10 +165,15 @@ class SupabaseClient {
     );
   }
 
-  Future<void> _closeSubscription(RealtimeSubscription subscription) async {
+  Future<SupabaseRealtimeError?> _closeSubscription(
+    RealtimeSubscription subscription,
+  ) async {
+    SupabaseRealtimeError? error;
     if (!subscription.isClosed()) {
-      await _closeChannel(subscription);
+      error = await _unsubscribeSubscription(subscription);
     }
+    realtime.remove(subscription);
+    return error;
   }
 
   Map<String, String> _getAuthHeaders() {
@@ -172,12 +184,30 @@ class SupabaseClient {
     return headers;
   }
 
-  Future<bool> _closeChannel(RealtimeSubscription subscription) {
-    final completer = Completer<bool>();
-    subscription.unsubscribe().receive('ok', (_) {
-      realtime.remove(subscription);
-      completer.complete(true);
-    }).receive('error', (e) => {completer.complete(false)});
+  /// Close channel [subscription] and return the result.
+  ///
+  /// in case of unsubscribe, remove the realtime connection and return null
+  /// in case of error return the error
+  Future<SupabaseRealtimeError?> _unsubscribeSubscription(
+    RealtimeSubscription subscription,
+  ) {
+    final completer = Completer<SupabaseRealtimeError?>();
+    subscription.unsubscribe().receive(
+      'ok',
+      (_) {
+        completer.complete(null);
+      },
+    ).receive(
+      'error',
+      (e) {
+        completer.completeError(SupabaseRealtimeError(e.toString()));
+      },
+    ).receive(
+      'timeout',
+      (e) {
+        completer.completeError(SupabaseRealtimeError(e.toString()));
+      },
+    );
     return completer.future;
   }
 

--- a/lib/src/supabase_realtime_error.dart
+++ b/lib/src/supabase_realtime_error.dart
@@ -1,0 +1,13 @@
+class SupabaseRealtimeError extends Error {
+  /// Creates an Unsubscribe error with the provided [message].
+  SupabaseRealtimeError([this.message]);
+  final Object? message;
+
+  @override
+  String toString() {
+    if (message != null) {
+      return "Unsubscribe failed: ${Error.safeToString(message)}";
+    }
+    return "Unsubscribe failed";
+  }
+}

--- a/lib/supabase.dart
+++ b/lib/supabase.dart
@@ -12,7 +12,9 @@ export 'package:storage_client/storage_client.dart';
 
 export 'src/auth_session.dart';
 export 'src/auth_user.dart';
+export 'src/remove_subscription_result.dart';
 export 'src/supabase.dart';
 export 'src/supabase_event_types.dart';
 export 'src/supabase_query_builder.dart';
+export 'src/supabase_realtime_error.dart';
 export 'src/supabase_realtime_payload.dart';

--- a/test/realtime_test.dart
+++ b/test/realtime_test.dart
@@ -31,33 +31,34 @@ void main() {
       await mockServer.close();
     });
 
-    test('''
-subscribe on existing subscription fail
-      1. create a subscription
-      2. subscribe on existing subscription
-    
-      expectation: 
-      - error
-    ''', () {
+    /// subscribe on existing subscription fail
+    ///
+    /// 1. create a subscription
+    /// 2. subscribe on existing subscription
+    ///
+    /// expectation:
+    /// - error
+    test('subscribe on existing subscription fail', () {
       final subscription = client
           .from('countries')
           .on(SupabaseEventTypes.insert, (_) {})
           .subscribe(
-            (event, {errorMsg}) => print('event: $event error: $errorMsg'),
+            (event, {errorMsg}) {},
           );
       expect(
         () => subscription.subscribe(),
         throwsA(const TypeMatcher<String>()),
       );
     });
-    test('''
-two realtime connections
-    1. subscribe on table insert event
-    2. subscribe on table update event
 
-    expectation: 
-    - 2 subscriptions
-    ''', () {
+    /// two realtime connections
+    ///
+    /// 1. subscribe on table insert event
+    /// 2. subscribe on table update event
+    ///
+    /// expectation:
+    /// - 2 subscriptions
+    test('two realtime connections', () {
       client
           .from('countries')
           .on(SupabaseEventTypes.insert, (_) {})
@@ -72,17 +73,17 @@ two realtime connections
         2,
       );
     });
-    test('''
-remove realtime connection
-    
-    1. subscribe on table insert event
-    2. subscribe on table update event
-    3. remove subscription on table insert event
-    
-    expectation: 
-    - result without error
-    - only one subscription
-    ''', () async {
+
+    /// remove realtime connection
+    ///
+    /// 1. subscribe on table insert event
+    /// 2. subscribe on table update event
+    /// 3. remove subscription on table insert event
+
+    /// expectation:
+    /// - result without error
+    /// - only one subscription
+    test('remove realtime connection', () async {
       final first = client
           .from('countries')
           .on(SupabaseEventTypes.insert, (event, {error}) {})
@@ -103,31 +104,26 @@ remove realtime connection
         1,
       );
     });
-    test('''
-remove multiple realtime connection
-    
-    1. subscribe on table insert event
-    2. subscribe on table update event
-    3. remove both subscriptions
-    
-    expectation:
-    - result 1 without error
-    - result 2 without error
-    - no subscriptions
-    ''', () async {
-      client.realtime.onOpen(() => print('socket opened'));
+
+    /// remove multiple realtime connection
+    ///
+    /// 1. subscribe on table insert event
+    /// 2. subscribe on table update event
+    /// 3. remove both subscriptions
+    ///
+    /// expectation:
+    /// - result 1 without error
+    /// - result 2 without error
+    /// - no subscriptions
+    test('remove multiple realtime connection', () async {
       final first = client
           .from('countries')
           .on(SupabaseEventTypes.insert, (event, {error}) {})
-          .subscribe(
-            (event, {errorMsg}) => print('1. event: $event error: $errorMsg'),
-          );
+          .subscribe();
       final second = client
           .from('countries')
           .on(SupabaseEventTypes.update, (event, {error}) {})
-          .subscribe(
-            (event, {errorMsg}) => print('2. event: $event error: $errorMsg'),
-          );
+          .subscribe();
       await Future.delayed(const Duration(seconds: 2), () {});
 
       final result1 = await client.removeSubscription(first);
@@ -148,18 +144,17 @@ remove multiple realtime connection
       );
     });
 
-    test('''
-remove all realtime connection
-        
-    1. subscribe on table insert event
-    2. subscribe on table update event
-    3. remove subscriptions with removeAllSubscriptions()
-    
-    expectation:
-    - result without error
-    - result with 2 items
-    - no subscriptions
-    ''', () async {
+    /// remove all realtime connection
+    ///
+    /// 1. subscribe on table insert event
+    /// 2. subscribe on table update event
+    /// 3. remove subscriptions with removeAllSubscriptions()
+    ///
+    /// expectation:
+    /// - result without error
+    /// - result with 2 items
+    /// - no subscriptions
+    test('remove all realtime connection', () async {
       client
           .from('countries')
           .on(SupabaseEventTypes.insert, (event, {error}) {})

--- a/test/realtime_test.dart
+++ b/test/realtime_test.dart
@@ -1,0 +1,108 @@
+import 'package:supabase/supabase.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('subscription: ', () {
+    late SupabaseClient client;
+    setUp(() {
+      client = SupabaseClient(
+        'https://xyz.supabase.co',
+        'key',
+      );
+    });
+    test('subscribe on existing subscription fail', () {
+      final subscription =
+          client.from('table').on(SupabaseEventTypes.insert, (_) {}).subscribe(
+                (event, {errorMsg}) => print('event: $event error: $errorMsg'),
+              );
+      expect(
+        () => subscription.subscribe(),
+        throwsA(const TypeMatcher<String>()),
+      );
+    });
+    test('two realtime connections', () {
+      client.from('table').on(SupabaseEventTypes.insert, (_) {}).subscribe();
+      client.from('table').on(SupabaseEventTypes.insert, (_) {}).subscribe();
+
+      expect(
+        client.getSubscriptions().length,
+        2,
+      );
+    });
+    test('remove realtime connection', () async {
+      final first = client
+          .from('table')
+          .on(SupabaseEventTypes.insert, (event, {error}) {})
+          .subscribe();
+
+      client
+          .from('table')
+          .on(SupabaseEventTypes.update, (event, {error}) {})
+          .subscribe();
+      final result = await client.removeSubscription(first);
+      expect(
+        result.error,
+        isNull,
+      );
+
+      expect(
+        client.getSubscriptions().length,
+        1,
+      );
+    });
+    test('remove multiple realtime connection', () async {
+      final first = client
+          .from('table')
+          .on(SupabaseEventTypes.insert, (event, {error}) {})
+          .subscribe();
+      final second = client
+          .from('table')
+          .on(SupabaseEventTypes.update, (event, {error}) {})
+          .subscribe();
+
+      final result1 = await client.removeSubscription(first);
+      final result2 = await client.removeSubscription(second);
+
+      expect(
+        result1.error,
+        isNull,
+      );
+      expect(
+        result2.error,
+        isNull,
+      );
+
+      expect(
+        client.getSubscriptions().length,
+        0,
+      );
+    });
+
+    test('remove all realtime connection', () async {
+      client
+          .from('table')
+          .on(SupabaseEventTypes.insert, (event, {error}) {})
+          .subscribe();
+
+      client
+          .from('table')
+          .on(SupabaseEventTypes.update, (event, {error}) {})
+          .subscribe();
+
+      final result1 = await client.removeAllSubscriptions();
+      expect(
+        result1,
+        isNotEmpty,
+      );
+      expect(
+        result1.length,
+        2,
+      );
+
+      expect(
+        client.getSubscriptions().length,
+        0,
+      );
+    });
+  });
+}


### PR DESCRIPTION
 remove inconsistency between supabase-js and supabase-dart client libraries on realtime remove functions.

breaking:
**removeAllSubscriptions** - returns list of removed subscriptions
**removeSubscription** - returns number of opened connections

@dshukertjr pls review PR, I don't know why, but I can't assign you as a reviewer.