### PR TITLE
fix: export storage types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [1.0.0-dev.2]
 
+- fix: export storage types
+
+## [1.0.0-dev.2]
+
 - feat: custom http client
 
 ## [1.0.0-dev.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## [1.0.0-dev.3]
 
 - fix: export storage types
+- BREAKING: update postgrest to [v1.0.0-dev.2](https://github.com/supabase-community/postgrest-dart/blob/master/CHANGELOG.md#100-dev2)
+- BREAKING: update gotrue to [v1.0.0-dev.2](https://github.com/supabase-community/gotrue-dart/blob/main/CHANGELOG.md#100-dev2)
+- feat: update storage to [v1.0.0-dev.2](https://github.com/supabase-community/storage-dart/blob/main/CHANGELOG.md#100-dev1)
 
 ## [1.0.0-dev.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [1.0.0-dev.2]
+## [1.0.0-dev.3]
 
 - fix: export storage types
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.0.0-dev.2';
+const version = '1.0.0-dev.3';

--- a/lib/supabase.dart
+++ b/lib/supabase.dart
@@ -8,6 +8,7 @@ export 'package:functions_client/functions_client.dart';
 export 'package:gotrue/gotrue.dart';
 export 'package:postgrest/postgrest.dart';
 export 'package:realtime_client/realtime_client.dart';
+export 'package:storage_client/storage_client.dart';
 
 export 'src/auth_session.dart';
 export 'src/auth_user.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,9 +9,9 @@ environment:
 
 dependencies:
   functions_client: ^1.0.0-dev.1
-  gotrue: ^1.0.0-dev.1
+  gotrue: ^1.0.0-dev.2
   http: ^0.13.4
-  postgrest: ^1.0.0-dev.1
+  postgrest: ^1.0.0-dev.2
   realtime_client: ^0.1.15
   storage_client: ^1.0.0-dev.2
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase
 description: A dart client for Supabase. This client makes it simple for developers to build secure and scalable products.
-version: 1.0.0-dev.2
+version: 1.0.0-dev.3
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/supabase-dart'
 
@@ -13,7 +13,7 @@ dependencies:
   http: ^0.13.4
   postgrest: ^1.0.0-dev.1
   realtime_client: ^0.1.15
-  storage_client: ^1.0.0-dev.1
+  storage_client: ^1.0.0-dev.2
 
 dev_dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
Currently you need to explicitly import the storage package to its types.
This requires supabase-community/storage-dart/pull/37 to be merged.