### PR TITLE
fix: stream types

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
   test:
     name: Test / OS ${{ matrix.os }} / Node ${{ matrix.node }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         node: ['12']

--- a/lib/src/supabase_stream_builder.dart
+++ b/lib/src/supabase_stream_builder.dart
@@ -24,7 +24,9 @@ class _Order {
   final bool ascending;
 }
 
-class SupabaseStreamBuilder extends Stream {
+typedef _StreamOutput = List<Map<String, dynamic>>;
+
+class SupabaseStreamBuilder extends Stream<_StreamOutput> {
   final PostgrestQueryBuilder _queryBuilder;
 
   final RealtimeChannel _channel;
@@ -37,10 +39,10 @@ class SupabaseStreamBuilder extends Stream {
   final List<String> _uniqueColumns;
 
   /// StreamController for `stream()` method.
-  late final StreamController<List<Map<String, dynamic>>> _streamController;
+  late final StreamController<_StreamOutput> _streamController;
 
   /// Contains the combined data of postgrest and realtime to emit as stream.
-  late final List<Map<String, dynamic>> _streamData;
+  late final _StreamOutput _streamData;
 
   /// `eq` filter used for both postgrest and realtime
   StreamPostgrestFilter? _streamFilter;
@@ -98,7 +100,7 @@ class SupabaseStreamBuilder extends Stream {
   }
 
   @Deprecated('Directly listen without execute instead. Deprecated in 1.0.0')
-  Stream<List<Map<String, dynamic>>> execute() {
+  Stream<_StreamOutput> execute() {
     _streamController = StreamController.broadcast(
       onCancel: () {
         if (!_streamController.hasListener) {
@@ -112,8 +114,8 @@ class SupabaseStreamBuilder extends Stream {
   }
 
   @override
-  StreamSubscription<List<Map<String, dynamic>>> listen(
-    void Function(List<Map<String, dynamic>> event)? onData, {
+  StreamSubscription<_StreamOutput> listen(
+    void Function(_StreamOutput event)? onData, {
     Function? onError,
     void Function()? onDone,
     bool? cancelOnError,
@@ -207,7 +209,7 @@ class SupabaseStreamBuilder extends Stream {
 
     try {
       final data = await (transformQuery ?? query);
-      final rows = List<Map<String, dynamic>>.from(data as List);
+      final rows = _StreamOutput.from(data as List);
       _streamData.addAll(rows);
       _addStream();
     } on PostgrestException catch (error) {
@@ -219,7 +221,7 @@ class SupabaseStreamBuilder extends Stream {
 
   bool _isTargetRecord({
     required Map<String, dynamic> record,
-    required Map<String, dynamic> payload,
+    required Map payload,
   }) {
     late final Map<String, dynamic> targetRecord;
     if (payload['eventType'] == 'UPDATE') {

--- a/lib/src/supabase_stream_builder.dart
+++ b/lib/src/supabase_stream_builder.dart
@@ -24,9 +24,9 @@ class _Order {
   final bool ascending;
 }
 
-typedef _StreamOutput = List<Map<String, dynamic>>;
+typedef SupabaseStreamEvent = List<Map<String, dynamic>>;
 
-class SupabaseStreamBuilder extends Stream<_StreamOutput> {
+class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   final PostgrestQueryBuilder _queryBuilder;
 
   final RealtimeChannel _channel;
@@ -39,10 +39,10 @@ class SupabaseStreamBuilder extends Stream<_StreamOutput> {
   final List<String> _uniqueColumns;
 
   /// StreamController for `stream()` method.
-  late final StreamController<_StreamOutput> _streamController;
+  late final StreamController<SupabaseStreamEvent> _streamController;
 
   /// Contains the combined data of postgrest and realtime to emit as stream.
-  late final _StreamOutput _streamData;
+  late final SupabaseStreamEvent _streamData;
 
   /// `eq` filter used for both postgrest and realtime
   StreamPostgrestFilter? _streamFilter;
@@ -100,7 +100,7 @@ class SupabaseStreamBuilder extends Stream<_StreamOutput> {
   }
 
   @Deprecated('Directly listen without execute instead. Deprecated in 1.0.0')
-  Stream<_StreamOutput> execute() {
+  Stream<SupabaseStreamEvent> execute() {
     _streamController = StreamController.broadcast(
       onCancel: () {
         if (!_streamController.hasListener) {
@@ -114,8 +114,8 @@ class SupabaseStreamBuilder extends Stream<_StreamOutput> {
   }
 
   @override
-  StreamSubscription<_StreamOutput> listen(
-    void Function(_StreamOutput event)? onData, {
+  StreamSubscription<SupabaseStreamEvent> listen(
+    void Function(SupabaseStreamEvent event)? onData, {
     Function? onError,
     void Function()? onDone,
     bool? cancelOnError,
@@ -209,7 +209,7 @@ class SupabaseStreamBuilder extends Stream<_StreamOutput> {
 
     try {
       final data = await (transformQuery ?? query);
-      final rows = _StreamOutput.from(data as List);
+      final rows = SupabaseStreamEvent.from(data as List);
       _streamData.addAll(rows);
       _addStream();
     } on PostgrestException catch (error) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/supabase-dart'
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.16.0 <3.0.0'
 
 dependencies:
   functions_client: 1.0.0-dev.4


### PR DESCRIPTION
I raised the min Dart version, to use type aliase. Postgrest already uses 2.16 so this doesn't change anything for devs.

Someone reported an issue on the [Discord](https://discord.com/channels/839993398554656828/869410418567831602/1018111988771070004) that you can't assign the stream to a typed variable. That's fixed by specifying the type on the extending `Stream`-
In addition, I fixed the typing on update call.

I don't have the time, but the stream method testing is weird. In normal run they pass, but in debug they don't.