### PR TITLE
chore: upgrade gotrue to 1.0.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   functions_client: ^1.0.0
-  gotrue: ^1.0.0
+  gotrue: ^1.0.2
   http: ^0.13.4
   postgrest: ^1.0.0
   realtime_client: ^1.0.0


### PR DESCRIPTION
## What kind of change does this PR introduce?

Dependency update (gotrue)

## What is the current behavior?

gotrue version is 1.0.0, which has a few bugs

## What is the new behavior?

gotrue version is 1.0.2, with bugs fixed

## Additional context

https://github.com/supabase-community/gotrue-dart/pull/97/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed
