### PR TITLE
fix: stream filter other than `eq` is not properly applied.

### DIFF
--- a/lib/src/supabase_query_builder.dart
+++ b/lib/src/supabase_query_builder.dart
@@ -29,13 +29,13 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder {
   /// [primaryKey] list of name of primary key column(s).
   ///
   /// ```dart
-  /// supabase.from('chats').stream(['my_primary_key']).execute().listen(_onChatsReceived);
+  /// supabase.from('chats').stream(primaryKey: ['my_primary_key']).execute().listen(_onChatsReceived);
   /// ```
   ///
   /// `eq`, `order`, `limit` filter are available to limit the data being queried.
   ///
   /// ```dart
-  /// supabase.from('chats:room_id=eq.123').stream(['my_primary_key']).order('created_at').limit(20).execute().listen(_onChatsReceived);
+  /// supabase.from('chats:room_id=eq.123').stream(primaryKey: ['my_primary_key']).order('created_at').limit(20).execute().listen(_onChatsReceived);
   /// ```
   SupabaseStreamBuilder stream({required List<String> primaryKey}) {
     assert(primaryKey.isNotEmpty, 'Please specify primary key column(s).');

--- a/lib/src/supabase_stream_builder.dart
+++ b/lib/src/supabase_stream_builder.dart
@@ -82,7 +82,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   /// Only one filter can be applied to `.stream()`.
   ///
   /// ```dart
-  /// supabase.from('users').stream(['id']).eq('name', 'Supabase');
+  /// supabase.from('users').stream(primaryKey: ['id']).eq('name', 'Supabase');
   /// ```
   SupabaseStreamBuilder eq(String column, dynamic value) {
     assert(
@@ -102,7 +102,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   /// Only one filter can be applied to `.stream()`.
   ///
   /// ```dart
-  /// supabase.from('users').stream(['id']).neq('name', 'Supabase');
+  /// supabase.from('users').stream(primaryKey: ['id']).neq('name', 'Supabase');
   /// ```
   SupabaseStreamBuilder neq(String column, dynamic value) {
     assert(
@@ -122,7 +122,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   /// Only one filter can be applied to `.stream()`.
   ///
   /// ```dart
-  /// supabase.from('users').stream(['id']).lt('likes', 100);
+  /// supabase.from('users').stream(primaryKey: ['id']).lt('likes', 100);
   /// ```
   SupabaseStreamBuilder lt(String column, dynamic value) {
     assert(
@@ -142,7 +142,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   /// Only one filter can be applied to `.stream()`.
   ///
   /// ```dart
-  /// supabase.from('users').stream(['id']).lte('likes', 100);
+  /// supabase.from('users').stream(primaryKey: ['id']).lte('likes', 100);
   /// ```
   SupabaseStreamBuilder lte(String column, dynamic value) {
     assert(
@@ -162,7 +162,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   /// Only one filter can be applied to `.stream()`.
   ///
   /// ```dart
-  /// supabase.from('users').stream(['id']).gt('likes', '100');
+  /// supabase.from('users').stream(primaryKey: ['id']).gt('likes', '100');
   /// ```
   SupabaseStreamBuilder gt(String column, dynamic value) {
     assert(
@@ -182,7 +182,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   /// Only one filter can be applied to `.stream()`.
   ///
   /// ```dart
-  /// supabase.from('users').stream(['id']).gte('likes', 100);
+  /// supabase.from('users').stream(primaryKey: ['id']).gte('likes', 100);
   /// ```
   SupabaseStreamBuilder gte(String column, dynamic value) {
     assert(
@@ -202,7 +202,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   /// When `ascending` value is true, the result will be in ascending order.
   ///
   /// ```dart
-  /// supabase.from('users').stream(['id']).order('username', ascending: false);
+  /// supabase.from('users').stream(primaryKey: ['id']).order('username', ascending: false);
   /// ```
   SupabaseStreamBuilder order(String column, {bool ascending = false}) {
     _orderBy = _Order(column: column, ascending: ascending);
@@ -212,7 +212,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   /// Limits the result with the specified `count`.
   ///
   /// ```dart
-  /// supabase.from('users').stream(['id']).limit(10);
+  /// supabase.from('users').stream(primaryKey: ['id']).limit(10);
   /// ```
   SupabaseStreamBuilder limit(int count) {
     _limit = count;

--- a/lib/src/supabase_stream_builder.dart
+++ b/lib/src/supabase_stream_builder.dart
@@ -244,7 +244,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   /// Sets up the stream controller and calls the method to get data as necessary
   void _setupStream() {
     final isFirstListener = _streamController == null;
-    _streamController ??= StreamController.broadcast(
+    _streamController = StreamController.broadcast(
       onListen: () {
         if (isFirstListener) {
           // Get the data from server on first listener

--- a/lib/src/supabase_stream_builder.dart
+++ b/lib/src/supabase_stream_builder.dart
@@ -284,9 +284,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
           event: 'UPDATE',
           schema: _schema,
           table: _table,
-          filter: _streamFilter != null
-              ? '${_streamFilter!.column}=eq.${_streamFilter!.value}'
-              : null,
+          filter: realtimeFilter,
         ), (payload, [ref]) {
       final updatedIndex = _streamData.indexWhere(
         (element) => _isTargetRecord(record: element, payload: payload),
@@ -304,9 +302,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
           event: 'DELETE',
           schema: _schema,
           table: _table,
-          filter: _streamFilter != null
-              ? '${_streamFilter!.column}=eq.${_streamFilter!.value}'
-              : null,
+          filter: realtimeFilter,
         ), (payload, [ref]) {
       final deletedIndex = _streamData.indexWhere(
         (element) => _isTargetRecord(record: element, payload: payload),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   postgrest: ^1.0.1
   realtime_client: ^1.0.0
   storage_client: ^1.0.0
+  rxdart: ^0.27.5
 
 dev_dependencies:
   lints: ^1.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   functions_client: ^1.0.0
   gotrue: ^1.0.0
   http: ^0.13.4
-  postgrest: ^1.0.0
+  postgrest: ^1.0.1
   realtime_client: ^1.0.0
   storage_client: ^1.0.0
 

--- a/test/mock_test.dart
+++ b/test/mock_test.dart
@@ -339,6 +339,17 @@ void main() {
 
         stream.listen(expectAsync1((event) {}, count: 4));
       });
+      test("can listen twice at the same time", () async {
+        final stream = client.from('todos').stream(primaryKey: ['id']);
+        stream.listen(expectAsync1((event) {}, count: 4));
+
+        await Future.delayed(Duration(seconds: 3));
+
+        // All realtime events are done emitting, so should receive the currnet data
+        stream.listen(expectAsync1((event) {
+          print('called');
+        }, count: 1));
+      });
       test('emits data', () {
         final stream = client.from('todos').stream(primaryKey: ['id']);
         expect(

--- a/test/mock_test.dart
+++ b/test/mock_test.dart
@@ -35,6 +35,13 @@ void main() {
         if (foundApiKey == customApiKey) {
           expect(headers.value('customfield'), 'customvalue');
         }
+
+        // Check that rest api contains the correct filter in the URL
+        if (testFilter != null) {
+          // Filter that should be applied in this request e.g. eq, neq, etc...
+          final filterType = testFilter.split('=').last.split('.').first;
+          expect(url.contains(filterType), isTrue);
+        }
       }
       if (url == '/rest/v1/todos?select=task%2Cstatus') {
         final jsonString = jsonEncode([

--- a/test/mock_test.dart
+++ b/test/mock_test.dart
@@ -342,13 +342,19 @@ void main() {
       test("can listen twice at the same time", () async {
         final stream = client.from('todos').stream(primaryKey: ['id']);
         stream.listen(expectAsync1((event) {}, count: 4));
+        stream.listen(expectAsync1((event) {}, count: 4));
+
+        // All realtime events are done emitting, so should receive the currnet data
+      });
+      test("stream should emit the last emitted data when listened to",
+          () async {
+        final stream = client.from('todos').stream(primaryKey: ['id']);
+        stream.listen(expectAsync1((event) {}, count: 4));
 
         await Future.delayed(Duration(seconds: 3));
 
         // All realtime events are done emitting, so should receive the currnet data
-        stream.listen(expectAsync1((event) {
-          print('called');
-        }, count: 1));
+        stream.listen(expectAsync1((event) {}, count: 1));
       });
       test('emits data', () {
         final stream = client.from('todos').stream(primaryKey: ['id']);

--- a/test/mock_test.dart
+++ b/test/mock_test.dart
@@ -21,7 +21,7 @@ void main() {
   /// `testFilter` is used to test incoming realtime filter. The value should match the realtime filter set by the library.
   Future<void> handleRequests(
     HttpServer server, {
-    String? testFilter,
+    String? expectedFilter,
   }) async {
     await for (final HttpRequest request in server) {
       final headers = request.headers;
@@ -37,10 +37,8 @@ void main() {
         }
 
         // Check that rest api contains the correct filter in the URL
-        if (testFilter != null) {
-          // Filter that should be applied in this request e.g. eq, neq, etc...
-          final filterType = testFilter.split('=').last.split('.').first;
-          expect(url.contains(filterType), isTrue);
+        if (expectedFilter != null) {
+          expect(url.contains(expectedFilter), isTrue);
         }
       }
       if (url == '/rest/v1/todos?select=task%2Cstatus') {
@@ -121,8 +119,8 @@ void main() {
                   ['postgres_changes']
               .first['filter'];
 
-          if (testFilter != null) {
-            expect(realtimeFilter, testFilter);
+          if (expectedFilter != null) {
+            expect(realtimeFilter, expectedFilter);
           }
 
           final replyString = jsonEncode({
@@ -483,7 +481,7 @@ void main() {
 
   group('realtime filter', () {
     test('can filter stream results with eq', () {
-      handleRequests(mockServer, testFilter: 'status=eq.true');
+      handleRequests(mockServer, expectedFilter: 'status=eq.true');
       final stream =
           client.from('todos').stream(primaryKey: ['id']).eq('status', true);
       expect(
@@ -501,35 +499,35 @@ void main() {
     });
 
     test('can filter stream results with neq', () {
-      handleRequests(mockServer, testFilter: 'id=neq.2');
+      handleRequests(mockServer, expectedFilter: 'id=neq.2');
       final stream =
           client.from('todos').stream(primaryKey: ['id']).neq('id', 2);
       expect(stream, emits(isList));
     });
 
     test('can filter stream results with gt', () {
-      handleRequests(mockServer, testFilter: 'id=gt.2');
+      handleRequests(mockServer, expectedFilter: 'id=gt.2');
       final stream =
           client.from('todos').stream(primaryKey: ['id']).gt('id', 2);
       expect(stream, emits(isList));
     });
 
     test('can filter stream results with gte', () {
-      handleRequests(mockServer, testFilter: 'id=gte.2');
+      handleRequests(mockServer, expectedFilter: 'id=gte.2');
       final stream =
           client.from('todos').stream(primaryKey: ['id']).gte('id', 2);
       expect(stream, emits(isList));
     });
 
     test('can filter stream results with lt', () {
-      handleRequests(mockServer, testFilter: 'id=lt.2');
+      handleRequests(mockServer, expectedFilter: 'id=lt.2');
       final stream =
           client.from('todos').stream(primaryKey: ['id']).lt('id', 2);
       expect(stream, emits(isList));
     });
 
     test('can filter stream results with lte', () {
-      handleRequests(mockServer, testFilter: 'id=lte.2');
+      handleRequests(mockServer, expectedFilter: 'id=lte.2');
       final stream =
           client.from('todos').stream(primaryKey: ['id']).lte('id', 2);
       expect(stream, emits(isList));

--- a/test/mock_test.dart
+++ b/test/mock_test.dart
@@ -495,22 +495,38 @@ void main() {
 
     test('can filter stream results with gt', () {
       handleRequests(mockServer, testFilter: 'id=gt.2');
-      client.from('todos').stream(primaryKey: ['id']).gt('id', 2);
+      client
+          .from('todos')
+          .stream(primaryKey: ['id'])
+          .gt('id', 2)
+          .listen((event) {});
     });
 
     test('can filter stream results with gte', () {
       handleRequests(mockServer, testFilter: 'id=gte.2');
-      client.from('todos').stream(primaryKey: ['id']).gte('id', 2);
+      client
+          .from('todos')
+          .stream(primaryKey: ['id'])
+          .gte('id', 2)
+          .listen((event) {});
     });
 
     test('can filter stream results with lt', () {
       handleRequests(mockServer, testFilter: 'id=lt.2');
-      client.from('todos').stream(primaryKey: ['id']).lt('id', 2);
+      client
+          .from('todos')
+          .stream(primaryKey: ['id'])
+          .lt('id', 2)
+          .listen((event) {});
     });
 
     test('can filter stream results with lte', () {
       handleRequests(mockServer, testFilter: 'id=lte.2');
-      client.from('todos').stream(primaryKey: ['id']).lte('id', 2);
+      client
+          .from('todos')
+          .stream(primaryKey: ['id'])
+          .lte('id', 2)
+          .listen((event) {});
     });
   });
 }

--- a/test/mock_test.dart
+++ b/test/mock_test.dart
@@ -94,6 +94,13 @@ void main() {
           ..headers.contentType = ContentType.json
           ..write(jsonString)
           ..close();
+      } else if (url.contains('rest')) {
+        // Just return an empty string as dummy data if any other rest request
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..headers.contentType = ContentType.json
+          ..write('[]')
+          ..close();
       } else if (url.contains('realtime')) {
         webSocket = await WebSocketTransformer.upgrade(request);
         if (hasListener) {
@@ -493,40 +500,39 @@ void main() {
       );
     });
 
+    test('can filter stream results with neq', () {
+      handleRequests(mockServer, testFilter: 'id=neq.2');
+      final stream =
+          client.from('todos').stream(primaryKey: ['id']).neq('id', 2);
+      expect(stream, emits(isList));
+    });
+
     test('can filter stream results with gt', () {
       handleRequests(mockServer, testFilter: 'id=gt.2');
-      client
-          .from('todos')
-          .stream(primaryKey: ['id'])
-          .gt('id', 2)
-          .listen((event) {});
+      final stream =
+          client.from('todos').stream(primaryKey: ['id']).gt('id', 2);
+      expect(stream, emits(isList));
     });
 
     test('can filter stream results with gte', () {
       handleRequests(mockServer, testFilter: 'id=gte.2');
-      client
-          .from('todos')
-          .stream(primaryKey: ['id'])
-          .gte('id', 2)
-          .listen((event) {});
+      final stream =
+          client.from('todos').stream(primaryKey: ['id']).gte('id', 2);
+      expect(stream, emits(isList));
     });
 
     test('can filter stream results with lt', () {
       handleRequests(mockServer, testFilter: 'id=lt.2');
-      client
-          .from('todos')
-          .stream(primaryKey: ['id'])
-          .lt('id', 2)
-          .listen((event) {});
+      final stream =
+          client.from('todos').stream(primaryKey: ['id']).lt('id', 2);
+      expect(stream, emits(isList));
     });
 
     test('can filter stream results with lte', () {
       handleRequests(mockServer, testFilter: 'id=lte.2');
-      client
-          .from('todos')
-          .stream(primaryKey: ['id'])
-          .lte('id', 2)
-          .listen((event) {});
+      final stream =
+          client.from('todos').stream(primaryKey: ['id']).lte('id', 2);
+      expect(stream, emits(isList));
     });
   });
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Filters other than `eq` is not applied properly. There is a bug where everything becomes an `eq` filter. This PR fixes it.

```dart
supabase.from('table').stream(primaryKey: ['id']).lt('id', 10); // only retrieves rows where id is 10
```

This PR also contains the following:
- Fix the comment docs of `.stream()` to use v1.0 code
- Listening to the same stream more than once will emit the most recent data without going out to the server